### PR TITLE
onPlayerDeathイベントハンドラでプライヤーをリスポーンさせる処理が動作確認のためコメントされたままであったのを有効化

### DIFF
--- a/src/main/java/com/example/randomdeathpawn/RandomDeathpawn.java
+++ b/src/main/java/com/example/randomdeathpawn/RandomDeathpawn.java
@@ -269,8 +269,8 @@ public class RandomDeathpawn extends JavaPlugin implements Listener {
         }
 
         // リスポーン処理
-        // player.spigot().respawn();
-        // player.getScheduler().runDelayed(this, (task) -> processRandomTeleport(player, TeleportReason.RESPAWN), null, 1L);
+        player.spigot().respawn();
+        player.getScheduler().runDelayed(this, (task) -> processRandomTeleport(player, TeleportReason.RESPAWN), null, 1L);
     }
         
     private void scheduleWeeklyReset() {


### PR DESCRIPTION
すみません
ぜんかいの修正では死亡即リスポーンの処理がコメントアウトされていました